### PR TITLE
Fix links

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -38,9 +38,9 @@ These are the official subdomains run by the is-a.dev staff team.
 
 - [`is-a.dev`](https://is-a.dev) (the root domain, used for the main page, documentation, and emails.)
 - [`all.is-a.dev`](https://all.is-a.dev) (visualization of [raw.is-a.dev](raw.is-a.dev), run by [@JustDeveloper1](https://github.com/JustDeveloper1).)
-- [`data.is-a.dev`](data.is-a.dev) (data visualization website, run by [@wdhdev](https://github.com/wdhdev).)
+- [`data.is-a.dev`](https://data.is-a.dev) (data visualization website, run by [@wdhdev](https://github.com/wdhdev).)
 - `docs.is-a.dev` (this website.)
-- [`raw.is-a.dev`](raw.is-a.dev) (raw JSON API of all is-a.dev subdomains, run by [@wdhdev](https://github.com/wdhdev).)
+- [`raw.is-a.dev`](https://raw.is-a.dev) (raw JSON API of all is-a.dev subdomains, run by [@wdhdev](https://github.com/wdhdev).)
 
 **Do *NOT* trust any websites claiming to be us that are not listed here. If you find any, please report them to [security@is-a.dev](mailto:security@is-a.dev).**
 


### PR DESCRIPTION
External links need `https://` at the beginning otherwise it will open a sub-page of the documentation which does not exist.