### PR TITLE
feat: remove description and repo fields from domain structure

### DIFF
--- a/src/useful/domain-structure.md
+++ b/src/useful/domain-structure.md
@@ -65,12 +65,6 @@ In the owner object, the fields `username` and `email` are required. You may add
 }
 ```
 
-### `description`
-Describe your domain name and your usage. This is purely for documentation purpose and is optional.
-
-### `repo`
-This is a link to your website repository or your GitHub account. This is purely for documentation purpose and is optional.
-
 ### `records` (required)
 This section is where you specify the DNS records.
 


### PR DESCRIPTION
Add services documentation and remove the `description` and `repo` keys.