### PR TITLE
Retype Community Pro Key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - uses: retypeapp/action-build@latest
+              env:
+                RETYPE_KEY: ${{ secrets.RETYPE_KEY }}
+
             - uses: actions/setup-dotnet@v1
               with:
                   dotnet-version: 7.0.x


### PR DESCRIPTION
Hey, I noticed you don't use Retype Community Pro key which is completely free provided by the Retype itself.

You can't remove the "Powered by Retype" advertisement but still can enjoy other Pro features.

### Pro Key:
```
dEVPBhEAT01MR0NBQ0xBT0VHR0NDR0dGT09PRUFDTEZARE9PT09FRERET15aEx0AHAEWWh0bT0Q-pId4N7uwS11nfzalpH2MG9Wql5Jtoc9vFnQMJJeh0WfKhv7CHrYPeg
```

### Blog
> https://retype.com/blog/2025-06-06-new-github-pages-community-key/#community-key