### PR TITLE
Update domain-structure.md to use a new more actuate example.

### DIFF
--- a/src/useful/domain-structure.md
+++ b/src/useful/domain-structure.md
@@ -182,7 +182,7 @@ See all supported record types in the [FAQ](./faq#which-records-are-supported).
   ```
 
   > Refer to the [FAQ](https://docs.is-a.dev/faq/#who-can-use-ns-records) for guidance on valid use cases.
-  > Example PR: [#16758](https://github.com/is-a-dev/register/pull/16758)
+  > Example PR: [#24565](https://github.com/is-a-dev/register/pull/24565)
 
 * **SRV**
   Defines service records:


### PR DESCRIPTION
I have found the the example PR [#16758](https://github.com/is-a-dev/register/pull/16758) is not an accurate example.
Some outer PRs with similar reasoning were closed without merging. (Including my own) I believe this was due to lack of reasoning and detail. I just thought I would help update the docs.
I appreciate the existence of this project, it is is absolutely needed for developer to be able to get a good subdomain for free.

Thank you.