### PR TITLE
docs: add warning callout to clarify plural 'records' key requirement

### DIFF
--- a/src/useful/domain-structure.md
+++ b/src/useful/domain-structure.md
@@ -105,6 +105,9 @@ Example:
 
 Specify your domain's DNS records.
 
+> [!IMPORTANT]
+> The JSON key must be plural: `"records"`. Using `"record"` (singular) will fail the automated validation checks.
+
 See all supported record types in the [FAQ](./faq#which-records-are-supported).
 
 #### Record Type Examples


### PR DESCRIPTION
### 📝 Description of Changes
This pull request adds a prominent callout warning in `src/useful/domain-structure.md` directly under the `records` section.

**Why this is needed:**
Even though the `is-a.dev` documentation is already 100% correct and consistently uses `"records"` (plural) in every single example, many first-time contributors still submit pull requests with the key written as `"record"` (singular). 

This happens because developers are linguistically accustomed to configuring a single DNS entry (e.g., "a CNAME record" or "a TXT record") and make the naming slip by association. Adding a prominent, visual warning block directly under the header will help capture their attention immediately and prevent these repetitive CI/CD linter failures.

---

### 🤝 Volunteering as a PR Reviewer
Hi `is-a.dev` maintainers,

First of all, thank you so much for building and maintaining this incredible platform for developers. It has been a fantastic resource for my own projects, and I would love to give back to the project.

Since the repository receives a very large volume of subdomain pull requests daily, **I would like to respectfully volunteer my time to help as a PR Reviewer for the organization**. 

I understand that triaging syntax mistakes, guiding first-time contributors, and merging pull requests takes a lot of maintainer cycles. I would be honored to help ease this load by reviewing incoming subdomain JSON files, helping contributors debug validation errors, and ensuring guidelines are followed. 

If there is an opening or a process to join the helper/review team, please let me know. I would be incredibly grateful for the opportunity to help support the community!

Thank you for your time and consideration,
Kishore (`@MKishoreDev`)